### PR TITLE
bump version to v1.0.5 in main.go file


### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.4"
+const Version = "1.0.5"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string


### PR DESCRIPTION
### Description
Bump the version to v1.0.5 in the main.go file. Update the version number to reflect the latest release.

### Changes
- Update version in main.go to v1.0.5
