### PR TITLE
bump version to 1.0.6 and update main.go to v1.0.5


### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.4"
+const Version = "1.0.5"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.5"
+const Version = "1.0.6"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string


### PR DESCRIPTION
### Description
Bump the version number to 1.0.6. Update the version in the main.go file to v1.0.5.

### Changes
- Bumped version to 1.0.6.
- Updated version in main.go to v1.0.5.
