### PR TITLE
bump version to 1.0.7 in main.go and update version history

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.6"
+const Version = "1.0.7"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.4"
+const Version = "1.0.5"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.5"
+const Version = "1.0.6"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string


### PR DESCRIPTION
### Description
Bump the version to 1.0.7 in `main.go` and update the version history. Ensure that all version references are consistent.

### Changes
- Update version to 1.0.7 in `main.go`
- Bump version to 1.0.6 in previous commits
- Update version history with recent changes