### PR TITLE
bump version from 1.0.7 to 1.0.8 in main.go


### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.6"
+const Version = "1.0.7"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.4"
+const Version = "1.0.5"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.5"
+const Version = "1.0.6"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.7"
+const Version = "1.0.8"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string


### PR DESCRIPTION
### Description
Bump the version from 1.0.7 to 1.0.8 in the main.go file. Update versioning information for consistency.

### Changes
- Update version to 1.0.8 in main.go
- Remove old version references
- Ensure versioning follows semantic guidelines
