### PR TITLE
bump version to **1.0.9** in `main.go` files


### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.8"
+const Version = "1.0.9"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.6"
+const Version = "1.0.7"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.4"
+const Version = "1.0.5"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.5"
+const Version = "1.0.6"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string

--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-const Version = "1.0.7"
+const Version = "1.0.8"
 
 //go:embed templates/systemInstructions.md
 var embeddedSystemInstructions string


### PR DESCRIPTION
### Description
Bump the version to **1.0.9** in the `main.go` file. Update previous versions maintained in the history to reflect consistency.

### Changes
- Update version from 1.0.8 to 1.0.9 in `main.go`
- Update version from 1.0.7 to 1.0.8 in `main.go`
- Update version to 1.0.7 in `main.go`
- Update version to 1.0.6 in `main.go`
- Update version to v1.0.5 in `main.go`

### Ticket links
- No ticket associated.
